### PR TITLE
Choose column

### DIFF
--- a/qiskit/transpiler/passes/synthesis/perm_row_col_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/perm_row_col_synthesis.py
@@ -84,7 +84,11 @@ class PermRowColSynthesis(HighLevelSynthesis):
         Returns:
             int: column index
         """
-        return 0
+        col_sum = [
+            sum(parity_mat[:, i]) if parity_mat[chosen_row][i] == 1 else len(parity_mat)
+            for i in cols
+        ]
+        return int(cols[np.argmin(col_sum)])
 
     def eliminate_column(
         self, parity_mat: np.ndarray, coupling: CouplingMap, root: int, terminals: np.ndarray

--- a/test/python/transpiler/test_perm_row_col_synthesis.py
+++ b/test/python/transpiler/test_perm_row_col_synthesis.py
@@ -49,12 +49,36 @@ class TestPermRowColSynthesis(QiskitTestCase):
         """Test the output type of choose_column"""
         coupling = CouplingMap()
         synthesis = PermRowColSynthesis(coupling)
-        parity_mat = np.ndarray(0)
-        cols = np.ndarray(0)
+        parity_mat = np.array([[1, 0], [0, 1]])
+        cols = np.array([0, 1])
 
         instance = synthesis.choose_column(parity_mat, cols, 0)
 
         self.assertIsInstance(instance, int)
+
+    def test_choose_column_returns_correct_index(self):
+        """Test choose_colum method for correctness"""
+        coupling = CouplingMap()
+        synthesis = PermRowColSynthesis(coupling)
+
+        parity_mat = np.array(
+            [
+                [0, 1, 0, 0, 0, 1, 0, 0, 0],
+                [0, 0, 0, 0, 1, 0, 0, 0, 0],
+                [0, 1, 0, 0, 0, 0, 0, 0, 0],
+                [1, 0, 1, 0, 1, 0, 1, 0, 1],
+                [0, 1, 0, 1, 0, 1, 0, 1, 0],
+                [1, 0, 0, 0, 1, 0, 1, 0, 0],
+                [0, 0, 0, 0, 0, 1, 0, 1, 0],
+                [0, 0, 1, 0, 0, 0, 1, 0, 1],
+                [0, 1, 0, 1, 0, 1, 0, 1, 0],
+            ]
+        )
+        vertices = np.array([1, 3, 4, 5, 6, 7])
+
+        index = synthesis.choose_column(parity_mat, vertices, 4)
+
+        self.assertEqual(index, 3)
 
     def test_eliminate_column_returns_int(self):
         """Test the output type of eliminate_column"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Implement choose_column method


### Details and comments
Implemented choose_column method in PermRowCol class such that
it returns the index of the column with the least amount of 1's
that also has a 1 in the selected row and is part of the
non-cutting vertices

Created unittests to test the updated choose_column

