### PR TITLE
Fix class method _pydigraph_to_pygraph

### DIFF
--- a/qiskit/transpiler/passes/synthesis/perm_row_col_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/perm_row_col_synthesis.py
@@ -124,5 +124,5 @@ class PermRowColSynthesis(HighLevelSynthesis):
         """
         return np.ndarray(0)
 
-    def _pydigraph_to_pygraph(pydigraph: rx.PyDiGraph) -> rx.PyGraph:
+    def _pydigraph_to_pygraph(self, pydigraph: rx.PyDiGraph) -> rx.PyGraph:
         return pydigraph.to_undirected()

--- a/test/python/transpiler/test_perm_row_col_synthesis.py
+++ b/test/python/transpiler/test_perm_row_col_synthesis.py
@@ -2,6 +2,7 @@
 
 import unittest
 import numpy as np
+import retworkx as rx
 from qiskit.test import QiskitTestCase
 from qiskit.transpiler.passes.synthesis.perm_row_col_synthesis import PermRowColSynthesis
 from qiskit import QuantumCircuit
@@ -114,6 +115,15 @@ class TestPermRowColSynthesis(QiskitTestCase):
         instance = synthesis.eliminate_row(parity_mat, coupling, 0, terminals)
 
         self.assertIsInstance(instance, np.ndarray)
+
+    def test_pydigraph_to_pygraph_returns_pygraph(self):
+        """Test the output type of _pydigraph_to_pygraph"""
+        coupling = CouplingMap()
+        synthesis = PermRowColSynthesis(coupling)
+
+        instance = synthesis._pydigraph_to_pygraph(coupling.graph)
+
+        self.assertIsInstance(instance, rx.PyGraph)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A test for class method _pydgraph_to_pygraph was added and a problem found in the method was fixed, argument 'self' was missing.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


