### PR TITLE
Add method _noncutting_vertices

### DIFF
--- a/qiskit/transpiler/passes/synthesis/perm_row_col_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/perm_row_col_synthesis.py
@@ -124,5 +124,21 @@ class PermRowColSynthesis(HighLevelSynthesis):
         """
         return np.ndarray(0)
 
-    def _pydigraph_to_pygraph(pydigraph: rx.PyDiGraph) -> rx.PyGraph:
+    def _pydigraph_to_pygraph(self, pydigraph: rx.PyDiGraph) -> rx.PyGraph:
         return pydigraph.to_undirected()
+
+    def _noncutting_vertices(self, coupling_map: CouplingMap) -> np.ndarray:
+        """Extracts noncutting vertices from a given coupling map. Direction is not taken into account.
+
+        Args:
+            coupling_map (CouplingMap): topology
+
+        Returns:
+            np.ndarray: array of non-cutting node indices
+        """
+        pygraph = self._pydigraph_to_pygraph(coupling_map.graph)
+        cutting_vertices = rx.articulation_points(pygraph)
+        vertices = set(pygraph.node_indices())
+        noncutting_vertices = np.array(list(vertices - cutting_vertices))
+
+        return noncutting_vertices

--- a/test/python/transpiler/test_perm_row_col_synthesis.py
+++ b/test/python/transpiler/test_perm_row_col_synthesis.py
@@ -115,6 +115,26 @@ class TestPermRowColSynthesis(QiskitTestCase):
 
         self.assertIsInstance(instance, np.ndarray)
 
+    def test_noncutting_vertices_returns_np_ndarray(self):
+        """Test the output type of _noncutting_vertices"""
+        coupling = CouplingMap()
+        synthesis = PermRowColSynthesis(coupling)
+
+        instance = synthesis._noncutting_vertices(coupling)
+
+        self.assertIsInstance(instance, np.ndarray)
+
+    def test_noncutting_vertices_returns_an_ndarray_with_noncutting_vertices(self):
+        """Test _noncutting_vertices method for correctness"""
+        coupling_list = [[0, 2], [1, 2], [2, 3], [2, 4], [3, 6], [4, 5], [4, 6]]
+        coupling = CouplingMap(couplinglist=coupling_list)
+        synthesis = PermRowColSynthesis(coupling)
+
+        instance = synthesis._noncutting_vertices(coupling)
+        expected = np.array([0, 1, 3, 5, 6])
+
+        self.assertCountEqual(instance, expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Added class method _noncutting_vertices for finding the noncutting vertices in a CouplingMap. Direction is not yet taken into account and the topology is treated as an undirected graph.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


