### PR TITLE
Postorder tree traversal

### DIFF
--- a/qiskit/transpiler/synthesis/graph_utils.py
+++ b/qiskit/transpiler/synthesis/graph_utils.py
@@ -48,8 +48,8 @@ def postorder_traversal(tree: rx.PyGraph, node: int, edges: list, parent: int = 
     Args:
         tree (rx.PyGraph): tree to traverse
         node (int): root node
-        parent (int): parent node
         edges (list): edge list
+        parent (int, optional): parent node. Defaults to None.
     """
     if node == None:
         return

--- a/qiskit/transpiler/synthesis/graph_utils.py
+++ b/qiskit/transpiler/synthesis/graph_utils.py
@@ -39,6 +39,7 @@ def noncutting_vertices(coupling_map: CouplingMap) -> np.ndarray:
 
     return noncutting
 
+
 def postorder_traversal(tree: rx.PyGraph, node: int, edges: list, parent: int = None):
     """Traverse the given tree in postorder. Traversed edges are saved as tuples.
     The first element is the parent and second the child.
@@ -50,7 +51,6 @@ def postorder_traversal(tree: rx.PyGraph, node: int, edges: list, parent: int = 
         parent (int): parent node
         edges (list): edge list
     """
-    print(edges)
     if node == None:
         return
     for n in sorted(tree.neighbors(node)):

--- a/qiskit/transpiler/synthesis/graph_utils.py
+++ b/qiskit/transpiler/synthesis/graph_utils.py
@@ -38,3 +38,24 @@ def noncutting_vertices(coupling_map: CouplingMap) -> np.ndarray:
     noncutting = np.array(list(vertices - cutting_vertices))
 
     return noncutting
+
+def postorder_traversal(tree: rx.PyGraph, node: int, edges: list, parent: int = None):
+    """Traverse the given tree in postorder. Traversed edges are saved as tuples.
+    The first element is the parent and second the child.
+    Children are visited in increasing order.
+
+    Args:
+        tree (rx.PyGraph): tree to traverse
+        node (int): root node
+        parent (int): parent node
+        edges (list): edge list
+    """
+    print(edges)
+    if node == None:
+        return
+    for n in sorted(tree.neighbors(node)):
+        if n == parent:
+            continue
+        postorder_traversal(tree, n, edges, node)
+    if parent != None:
+        edges.append((parent, node))

--- a/test/python/transpiler/test_graph_utils.py
+++ b/test/python/transpiler/test_graph_utils.py
@@ -48,9 +48,11 @@ class TestGraphUtils(QiskitTestCase):
         tree.add_nodes_from([0, 1, 2, 3, 4])
         tree.add_edges_from([(0, 1, 1), (1, 2, 1), (1, 3, 1), (1, 4, 1)])
         result = []
-        postorder_traversal(tree, 0, result)
 
-        self.assertEqual(result, [(1, 2), (1, 3), (1, 4), (0, 1)])
+        postorder_traversal(tree, 0, result)
+        expected = [(1, 2), (1, 3), (1, 4), (0, 1)]
+
+        self.assertEqual(result, expected)
 
     def test_postorder_traversal_returns_empty_list_if_root_node_not_in_tree(self):
         """Test that postorder_traversal returns empty edge list if the given

--- a/test/python/transpiler/test_graph_utils.py
+++ b/test/python/transpiler/test_graph_utils.py
@@ -5,7 +5,11 @@ import numpy as np
 import retworkx as rx
 
 from qiskit.test import QiskitTestCase
-from qiskit.transpiler.synthesis.graph_utils import noncutting_vertices, pydigraph_to_pygraph, postorder_traversal
+from qiskit.transpiler.synthesis.graph_utils import (
+    noncutting_vertices,
+    pydigraph_to_pygraph,
+    postorder_traversal,
+)
 from qiskit.transpiler import CouplingMap
 
 

--- a/test/python/transpiler/test_graph_utils.py
+++ b/test/python/transpiler/test_graph_utils.py
@@ -5,7 +5,7 @@ import numpy as np
 import retworkx as rx
 
 from qiskit.test import QiskitTestCase
-from qiskit.transpiler.synthesis.graph_utils import noncutting_vertices, pydigraph_to_pygraph
+from qiskit.transpiler.synthesis.graph_utils import noncutting_vertices, pydigraph_to_pygraph, postorder_traversal
 from qiskit.transpiler import CouplingMap
 
 
@@ -37,6 +37,37 @@ class TestGraphUtils(QiskitTestCase):
         instance = pydigraph_to_pygraph(coupling.graph)
 
         self.assertIsInstance(instance, rx.PyGraph)
+
+    def test_postorder_traversal_returns_correct_edges(self):
+        """Test that postorder_traversal returns correct edge list"""
+        tree = rx.PyGraph()
+        tree.add_nodes_from([0, 1, 2, 3, 4])
+        tree.add_edges_from([(0, 1, 1), (1, 2, 1), (1, 3, 1), (1, 4, 1)])
+        result = []
+        postorder_traversal(tree, 0, result)
+
+        self.assertEqual(result, [(1, 2), (1, 3), (1, 4), (0, 1)])
+
+    def test_postorder_traversal_returns_empty_list_if_root_node_not_in_tree(self):
+        """Test that postorder_traversal returns empty edge list if the given
+        node is not found in the tree"""
+        tree = rx.PyGraph()
+        tree.add_nodes_from([0, 1, 2, 3])
+        tree.add_edges_from([(0, 1, 1), (1, 2, 1), (1, 3, 1)])
+        result = []
+        postorder_traversal(tree, 5, result)
+
+        self.assertEqual(result, [])
+
+    def test_postorder_traversal_returns_empty_list_for_tree_with_no_edges(self):
+        """Test that postorder_traversal returns empty edge list if the given
+        tree doesn't have any edges"""
+        tree = rx.PyGraph()
+        tree.add_nodes_from([0])
+        result = []
+        postorder_traversal(tree, 0, result)
+
+        self.assertEqual(result, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Implement a method for postorder traversal of edges of a given undirected tree.


### Details and comments
There are no checks for the input, so it's the caller's responsibility to make sure that the graph is a tree, the root node can be found in the graph etc. Any comments on this? If this is a public function, should there then be some checks for the input?

