### PR TITLE
Non cutting vertices graph

### DIFF
--- a/qiskit/transpiler/synthesis/graph_utils.py
+++ b/qiskit/transpiler/synthesis/graph_utils.py
@@ -23,16 +23,16 @@ def pydigraph_to_pygraph(pydigraph: rx.PyDiGraph) -> rx.PyGraph:
     return pydigraph.to_undirected()
 
 
-def noncutting_vertices(coupling_map: CouplingMap) -> np.ndarray:
-    """Extracts noncutting vertices from a given coupling map. Direction is not taken into account.
+def noncutting_vertices(coupling_map_graph: rx.PyDiGraph) -> np.ndarray:
+    """Extracts noncutting vertices from a given coupling map graph. Direction is not taken into account.
 
     Args:
-        coupling_map (CouplingMap): topology
+        coupling_map (rx.PyDiGraph): graph of topology
 
     Returns:
         np.ndarray: array of non-cutting node indices
     """
-    pygraph = pydigraph_to_pygraph(coupling_map.graph)
+    pygraph = pydigraph_to_pygraph(coupling_map_graph)
     cutting_vertices = rx.articulation_points(pygraph)
     vertices = set(pygraph.node_indices())
     noncutting = np.array(list(vertices - cutting_vertices))

--- a/qiskit/transpiler/synthesis/graph_utils.py
+++ b/qiskit/transpiler/synthesis/graph_utils.py
@@ -23,16 +23,15 @@ def pydigraph_to_pygraph(pydigraph: rx.PyDiGraph) -> rx.PyGraph:
     return pydigraph.to_undirected()
 
 
-def noncutting_vertices(coupling_map_graph: rx.PyDiGraph) -> np.ndarray:
+def noncutting_vertices(pygraph: rx.PyGraph) -> np.ndarray:
     """Extracts noncutting vertices from a given coupling map graph. Direction is not taken into account.
 
     Args:
-        coupling_map (rx.PyDiGraph): graph of topology
+        pygraph (rx.PyGraph): undirected graph of topology
 
     Returns:
         np.ndarray: array of non-cutting node indices
     """
-    pygraph = pydigraph_to_pygraph(coupling_map_graph)
     cutting_vertices = rx.articulation_points(pygraph)
     vertices = set(pygraph.node_indices())
     noncutting = np.array(list(vertices - cutting_vertices))

--- a/qiskit/transpiler/synthesis/permrowcol.py
+++ b/qiskit/transpiler/synthesis/permrowcol.py
@@ -30,7 +30,7 @@ class PermRowCol:
 
     def __init__(self, coupling_map: CouplingMap):
         self._coupling_map = coupling_map
-        self._graph = coupling_map.graph
+        self._graph = pydigraph_to_pygraph(self._coupling_map.graph)
 
     def perm_row_col(self, parity_mat: np.ndarray) -> QuantumCircuit:
         """Run permrowcol algorithm on the given parity matrix
@@ -151,7 +151,7 @@ class PermRowCol:
             list: list of tuples represents control and target qubits with a cnot gate between them.
         """
         C = []
-        tree = rx.steiner_tree(pydigraph_to_pygraph(self._graph), terminals, weight_fn=lambda x: 1)
+        tree = rx.steiner_tree(self._graph, terminals, weight_fn=lambda x: 1)
         post_edges = []
         postorder_traversal(tree, root, post_edges)
 
@@ -179,7 +179,7 @@ class PermRowCol:
             list of tuples represents control and target qubits with a cnot gate between them.
         """
         C = []
-        tree = rx.steiner_tree(pydigraph_to_pygraph(self._graph), terminals, weight_fn=lambda x: 1)
+        tree = rx.steiner_tree(self._graph, terminals, weight_fn=lambda x: 1)
 
         pre_edges = []
         preorder_traversal(tree, root, pre_edges)

--- a/qiskit/transpiler/synthesis/permrowcol.py
+++ b/qiskit/transpiler/synthesis/permrowcol.py
@@ -46,9 +46,7 @@ class PermRowCol:
         circuit = QuantumCircuit(len(self._graph.node_indexes()))
 
         while len(self._graph.node_indexes()) > 1:
-            n_vertices = noncutting_vertices(
-                CouplingMap()
-            )  # Have to change noncutting_vertices for pydigraph
+            n_vertices = noncutting_vertices(self._graph)
             row = self.choose_row(n_vertices, parity_mat)
 
             cols = self.return_columns(qubit_alloc)

--- a/test/python/transpiler/test_graph_utils.py
+++ b/test/python/transpiler/test_graph_utils.py
@@ -19,7 +19,7 @@ class TestGraphUtils(QiskitTestCase):
 
     def test_noncutting_vertices_returns_np_ndarray(self):
         """Test the output type of noncutting_vertices"""
-        graph = CouplingMap().graph
+        graph = pydigraph_to_pygraph(CouplingMap().graph)
 
         instance = noncutting_vertices(graph)
 
@@ -28,7 +28,7 @@ class TestGraphUtils(QiskitTestCase):
     def test_noncutting_vertices_returns_an_ndarray_with_noncutting_vertices(self):
         """Test noncutting_vertices method for correctness"""
         coupling_list = [[0, 2], [1, 2], [2, 3], [2, 4], [3, 6], [4, 5], [4, 6]]
-        graph = CouplingMap(couplinglist=coupling_list).graph
+        graph = pydigraph_to_pygraph(CouplingMap(couplinglist=coupling_list).graph)
 
         instance = noncutting_vertices(graph)
         expected = np.array([0, 1, 3, 5, 6])

--- a/test/python/transpiler/test_graph_utils.py
+++ b/test/python/transpiler/test_graph_utils.py
@@ -19,18 +19,18 @@ class TestGraphUtils(QiskitTestCase):
 
     def test_noncutting_vertices_returns_np_ndarray(self):
         """Test the output type of noncutting_vertices"""
-        coupling = CouplingMap()
+        graph = CouplingMap().graph
 
-        instance = noncutting_vertices(coupling)
+        instance = noncutting_vertices(graph)
 
         self.assertIsInstance(instance, np.ndarray)
 
     def test_noncutting_vertices_returns_an_ndarray_with_noncutting_vertices(self):
         """Test noncutting_vertices method for correctness"""
         coupling_list = [[0, 2], [1, 2], [2, 3], [2, 4], [3, 6], [4, 5], [4, 6]]
-        coupling = CouplingMap(couplinglist=coupling_list)
+        graph = CouplingMap(couplinglist=coupling_list).graph
 
-        instance = noncutting_vertices(coupling)
+        instance = noncutting_vertices(graph)
         expected = np.array([0, 1, 3, 5, 6])
 
         self.assertCountEqual(instance, expected)

--- a/test/python/transpiler/test_permrowcol.py
+++ b/test/python/transpiler/test_permrowcol.py
@@ -295,12 +295,12 @@ class TestPermRowCol(QiskitTestCase):
         instance = permrowcol.get_nodes(np.array([[1, 0, 1], [0, 1, 1], [0, 0, 1]]), 0)
         self.assertCountEqual(instance, [0])
 
-        coupling.graph.remove_node(1)
+        permrowcol.reduce_graph(1)
 
         instance = permrowcol.get_nodes(np.array([[1, 0, 1], [0, 1, 1], [0, 0, 1]]), 2)
         self.assertCountEqual(instance, [0, 2])
 
-        coupling.graph.remove_node(0)
+        permrowcol.reduce_graph(0)
 
         instance = permrowcol.get_nodes(np.array([[1, 0, 1], [0, 1, 1], [0, 0, 1]]), 0)
         self.assertCountEqual(instance, [])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Modified noncutting_vertices() function to use coupling map graph instead of coupling map


### Details and comments
The reason for this change is that the permrowcol function, if coupling map is not empty, should get n_vertices from the topology given to the class object, but before this change, n_vertices are derived from an empty coupling map no matter what the class variable self._coupling_map is. When noncutting vertices are derived from the class variable self._graph, the noncutting vertices should be actually correct.

