### PR TITLE
Permrowcol add return value

### DIFF
--- a/qiskit/transpiler/passes/synthesis/perm_row_col_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/perm_row_col_synthesis.py
@@ -46,5 +46,5 @@ class PermRowColSynthesis(LinearFunctionsSynthesis):
 
         parity_mat = np.identity(3)
         permrowcol = PermRowCol(self._coupling_map)
-        res_circuit = permrowcol.perm_row_col(parity_mat)
-        return circuit_to_dag(res_circuit)
+        circuit, perm = permrowcol.perm_row_col(parity_mat)
+        return circuit_to_dag(circuit)

--- a/qiskit/transpiler/synthesis/permrowcol.py
+++ b/qiskit/transpiler/synthesis/permrowcol.py
@@ -23,6 +23,7 @@ from qiskit.transpiler.synthesis.graph_utils import (
     pydigraph_to_pygraph,
     noncutting_vertices,
 )
+from qiskit.circuit.library.generalized_gates.permutation import Permutation
 
 
 class PermRowCol:
@@ -41,6 +42,7 @@ class PermRowCol:
         Returns:
             QuantumCircuit: synthesized circuit
         """
+        num_qubits = len(self._graph.node_indexes())
         qubit_alloc = [-1] * len(self._graph.node_indexes())
 
         circuit = QuantumCircuit(len(self._graph.node_indexes()))
@@ -68,7 +70,13 @@ class PermRowCol:
         if len(qubit_alloc) != 0:
             qubit_alloc[qubit_alloc.index(-1)] = self._graph.node_indexes()[0]
 
-        return circuit  # Supposed to also return qubit_alloc?
+        try:
+            perm = Permutation(num_qubits, qubit_alloc)
+        except:
+            print("Invalid qubit allocation vector:", qubit_alloc)
+            return (circuit, None)
+
+        return circuit, perm
 
     def reduce_graph(self, node: int):
         """Removes a node from pydigraph

--- a/qiskit/transpiler/synthesis/permrowcol.py
+++ b/qiskit/transpiler/synthesis/permrowcol.py
@@ -24,6 +24,7 @@ from qiskit.transpiler.synthesis.graph_utils import (
     noncutting_vertices,
 )
 from qiskit.circuit.library.generalized_gates.permutation import Permutation
+from qiskit.circuit.exceptions import CircuitError
 
 
 class PermRowCol:
@@ -72,9 +73,10 @@ class PermRowCol:
 
         try:
             perm = Permutation(num_qubits, qubit_alloc)
-        except:
-            print("Invalid qubit allocation vector:", qubit_alloc)
-            return (circuit, None)
+        except CircuitError:
+            raise RuntimeError(
+                f"Formed qubit allocation vector is not a valid permutation pattern: {qubit_alloc}"
+            )
 
         return circuit, perm
 

--- a/qiskit/transpiler/synthesis/permrowcol.py
+++ b/qiskit/transpiler/synthesis/permrowcol.py
@@ -55,7 +55,7 @@ class PermRowCol:
             cols = self._return_columns(qubit_alloc)
             column = self.choose_column(parity_mat, cols, row)
             nodes = self._get_nodes(parity_mat, column)
-            for edge in self.eliminate_column(parity_mat, row, column, nodes):
+            for edge in self._eliminate_column(parity_mat, row, column, nodes):
                 circuit.cx(edge[0], edge[1])
 
             if sum(parity_mat[row]) > 1:

--- a/qiskit/transpiler/synthesis/permrowcol.py
+++ b/qiskit/transpiler/synthesis/permrowcol.py
@@ -44,9 +44,9 @@ class PermRowCol:
             QuantumCircuit: synthesized circuit
         """
         num_qubits = len(self._graph.node_indexes())
-        qubit_alloc = [-1] * len(self._graph.node_indexes())
+        qubit_alloc = [-1] * num_qubits
 
-        circuit = QuantumCircuit(len(self._graph.node_indexes()))
+        circuit = QuantumCircuit(num_qubits)
 
         while len(self._graph.node_indexes()) > 1:
             n_vertices = noncutting_vertices(self._graph)

--- a/test/python/transpiler/test_permrowcol.py
+++ b/test/python/transpiler/test_permrowcol.py
@@ -90,7 +90,7 @@ class TestPermRowCol(QiskitTestCase):
         permrowcol = PermRowCol(coupling)
         parity_mat = np.identity(6)
 
-        instance = permrowcol.perm_row_col(parity_mat)
+        instance = permrowcol.perm_row_col(parity_mat)[0]
         self.assertEqual(len(instance.data), 0)
 
     def test_perm_row_col_doesnt_return_cnots_with_identity_matrix_permutation(self):
@@ -101,7 +101,7 @@ class TestPermRowCol(QiskitTestCase):
         parity_mat = np.identity(6)
         np.random.shuffle(parity_mat)
 
-        instance = permrowcol.perm_row_col(parity_mat)
+        instance = permrowcol.perm_row_col(parity_mat)[0]
         self.assertEqual(len(instance.data), 0)
 
     def test_choose_row_returns_np_int64(self):

--- a/test/python/transpiler/test_permrowcol.py
+++ b/test/python/transpiler/test_permrowcol.py
@@ -39,22 +39,26 @@ class TestPermRowCol(QiskitTestCase):
         self.assertIsNotNone(perm)
         self.assertEqual(perm, expected_perm)
 
-    def test_perm_row_col_returns_correct_permutation_on_random_permutation_matrix(self):
+    def test_perm_row_col_returns_correct_permutation_on_permutation_matrix(self):
         """Test that perm_row_col returns correct permutation circuit when parity matrix
         is a permutation of identity matrix"""
         coupling_list = [(0, 1), (0, 3), (1, 2), (1, 4), (2, 5), (3, 4), (4, 5)]
         coupling = CouplingMap(coupling_list)
         permrowcol = PermRowCol(coupling)
-        parity_mat = np.identity(6)
-        np.random.shuffle(parity_mat)
-        pattern = []
-        for elem in parity_mat.T.tolist():
-            pattern.extend([i for i, e in enumerate(elem) if e == 1])
-        expected_perm = Permutation(6, pattern)
+        parity_mat = np.array(
+            [
+                [1, 0, 0, 0, 0, 0],
+                [0, 0, 0, 1, 0, 0],
+                [0, 0, 0, 0, 0, 1],
+                [0, 0, 0, 0, 1, 0],
+                [0, 0, 1, 0, 0, 0],
+                [0, 1, 0, 0, 0, 0],
+            ]
+        )
+        expected_perm = Permutation(6, [0, 5, 4, 1, 3, 2])
 
         perm = permrowcol.perm_row_col(parity_mat)[1]
 
-        self.assertIsNotNone(perm)
         self.assertEqual(perm, expected_perm)
 
     def test_perm_row_col_returns_correct_permutation(self):

--- a/test/python/transpiler/test_permrowcol.py
+++ b/test/python/transpiler/test_permrowcol.py
@@ -36,7 +36,6 @@ class TestPermRowCol(QiskitTestCase):
 
         perm = permrowcol.perm_row_col(parity_mat)[1]
 
-        self.assertIsNotNone(perm)
         self.assertEqual(perm, expected_perm)
 
     def test_perm_row_col_returns_correct_permutation_on_permutation_matrix(self):

--- a/test/python/transpiler/test_permrowcol.py
+++ b/test/python/transpiler/test_permrowcol.py
@@ -13,7 +13,7 @@ from qiskit.transpiler import CouplingMap
 class TestPermRowCol(QiskitTestCase):
     """Test PermRowCol"""
 
-    def test_perm_row_col_returns_circuit(self):
+    def test_perm_row_col_returns_two_circuits(self):
         """Test the output type of perm_row_col"""
         coupling = CouplingMap()
         permrowcol = PermRowCol(coupling)
@@ -21,7 +21,8 @@ class TestPermRowCol(QiskitTestCase):
 
         instance = permrowcol.perm_row_col(parity_mat)
 
-        self.assertIsInstance(instance, QuantumCircuit)
+        self.assertIsInstance(instance[0], QuantumCircuit)
+        self.assertIsInstance(instance[1], QuantumCircuit)
 
     def test_choose_row_returns_np_int64(self):
         """Test the output type of choose_row"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Return a Permutation object in addition to the synthesized circuit. Add tests for the trivial cases (parity matrix is an identity matrix or a permutation matrix) and one for a more realistic parity matrix. I also did a very small refactoring of a variable in `perm_row_col`.


### Details and comments
The tests for permutation matrix and realistic parity matrix are not passing yet.
I'm also unsure about how we should deal with the possible `CircuitError` that is thrown in the `init` of qiskit/circuit/library/generalized_gates/permutation.py if our qubit allocation vector is not a valid permutation pattern. Now I just raise a `RuntimeError` with the qubit allocation vector to let us see what's wrong with it.

