### PR TITLE
Test perm_row_col with identity matrix

### DIFF
--- a/qiskit/transpiler/synthesis/permrowcol.py
+++ b/qiskit/transpiler/synthesis/permrowcol.py
@@ -53,7 +53,7 @@ class PermRowCol:
             cols = self._return_columns(qubit_alloc)
             column = self.choose_column(parity_mat, cols, row)
             nodes = self._get_nodes(parity_mat, column)
-            for edge in self.eliminate_column(parity_mat, row, column, nodes):
+            for edge in self._eliminate_column(parity_mat, row, column, nodes):
                 circuit.cx(edge[0], edge[1])
 
             if sum(parity_mat[row]) > 1:

--- a/test/python/transpiler/test_permrowcol.py
+++ b/test/python/transpiler/test_permrowcol.py
@@ -23,6 +23,27 @@ class TestPermRowCol(QiskitTestCase):
 
         self.assertIsInstance(instance, QuantumCircuit)
 
+    def test_perm_row_col_doesnt_return_cnots_with_identity_matrix(self):
+        """Test that permrowcol doesn't return any cnots when matrix as parity matrix is identity matrix"""
+        coupling_list = [(0, 1), (0, 3), (1, 2), (1, 4), (2, 5), (3, 4), (4, 5)]
+        coupling = CouplingMap(coupling_list)
+        permrowcol = PermRowCol(coupling)
+        parity_mat = np.identity(6)
+
+        instance = permrowcol.perm_row_col(parity_mat)
+        self.assertEqual(len(instance.data), 0)
+
+    def test_perm_row_col_doesnt_return_cnots_with_identity_matrix_permutation(self):
+        """Test that permrowcol doesn't return any cnots when matrix as parity matrix is permutation of identity matrix"""
+        coupling_list = [(0, 1), (0, 3), (1, 2), (1, 4), (2, 5), (3, 4), (4, 5)]
+        coupling = CouplingMap(coupling_list)
+        permrowcol = PermRowCol(coupling)
+        parity_mat = np.identity(6)
+        np.random.shuffle(parity_mat)
+
+        instance = permrowcol.perm_row_col(parity_mat)
+        self.assertEqual(len(instance.data), 0)
+
     def test_choose_row_returns_np_int64(self):
         """Test the output type of choose_row"""
         coupling = CouplingMap()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Test that id parity matrix is identity matrix or permutation of identity matrix no cnots are returned.



### Details and comments


