### PR TITLE
Add test for perm_row_col()

### DIFF
--- a/test/python/transpiler/test_permrowcol.py
+++ b/test/python/transpiler/test_permrowcol.py
@@ -10,6 +10,8 @@ from qiskit.circuit.library import LinearFunction
 from qiskit import QuantumCircuit, QuantumRegister
 from qiskit.transpiler import CouplingMap
 from qiskit.circuit.library.generalized_gates.permutation import Permutation
+from qiskit.transpiler.synthesis.matrix_utils import build_random_parity_matrix
+from qiskit.providers.fake_provider import FakeManilaV2
 
 
 class TestPermRowCol(QiskitTestCase):
@@ -103,6 +105,20 @@ class TestPermRowCol(QiskitTestCase):
 
         instance = permrowcol.perm_row_col(parity_mat)[0]
         self.assertEqual(len(instance.data), 0)
+
+    def test_perm_row_col_returns_valid_output_with_a_common_case(self):
+        """Test the output of perm_row_col for correctness"""
+        backend = FakeManilaV2()
+        coupling_map = backend.coupling_map
+        coupling = CouplingMap(coupling_map)
+        permrowcol = PermRowCol(coupling)
+        parity_mat = build_random_parity_matrix(42, 5, 60)
+        original_parity_map = parity_mat.copy()
+        circuit, perm = permrowcol.perm_row_col(parity_mat)
+        circuit_matrix = LinearFunction(circuit).linear.astype(int)
+        t_circuit_matrix = np.transpose(circuit_matrix)
+        instance = np.matmul(t_circuit_matrix, parity_mat)
+        self.assertEqual(np.array_equal(instance, original_parity_map), True)
 
     def test_choose_row_returns_np_int64(self):
         """Test the output type of choose_row"""


### PR DESCRIPTION
Add test for common case of coupling map to test the functionality of perm_row_col() function in class PermRowCol

Co-authored-by: Pihjoe <joel.pihlaja@helsinki.fi>
Co-authored-by: jova486 <jorma.valjakka@helsinki.fi>

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Added a test for `PermRowCol` class function `perm_row_col()` using a coupling map from a fake backend `FakeManilaV2` and a random parity matrix.



### Details and comments


