### PR TITLE
Add hadamard gates

### DIFF
--- a/qiskit/transpiler/synthesis/permrowcol.py
+++ b/qiskit/transpiler/synthesis/permrowcol.py
@@ -257,7 +257,7 @@ class PermRowCol:
         if edge not in edges:
             circuit.h(edge[0])
             circuit.h(edge[1])
-            circuit.cx(edge[0], edge[1])
+            circuit.cx(edge[1], edge[0])
             circuit.h(edge[0])
             circuit.h(edge[1])
 

--- a/qiskit/transpiler/synthesis/permrowcol.py
+++ b/qiskit/transpiler/synthesis/permrowcol.py
@@ -57,15 +57,15 @@ class PermRowCol:
             column = self.choose_column(parity_mat, cols, row)
             nodes = self._get_nodes(parity_mat, column)
             for edge in self._eliminate_column(parity_mat, row, column, nodes):
-                #circuit.cx(edge[0], edge[1])
-                self._add_cnot(edge,circuit)
+                # circuit.cx(edge[0], edge[1])
+                self._add_cnot(edge, circuit)
 
             if sum(parity_mat[row]) > 1:
                 nodes = self._get_nodes_for_eliminate_row(parity_mat, column, row)
 
                 for edge in self._eliminate_row(parity_mat, row, nodes):
-                    #circuit.cx(edge[0], edge[1])  # Adds a CNOT to the circuit
-                    self._add_cnot(edge,circuit)
+                    # circuit.cx(edge[0], edge[1])  # Adds a CNOT to the circuit
+                    self._add_cnot(edge, circuit)
 
             qubit_alloc[column] = row
 
@@ -245,11 +245,9 @@ class PermRowCol:
 
         return nodes
 
-    def _add_cnot(
-        self, edge: tuple, circuit: QuantumCircuit
-    ) -> list:
+    def _add_cnot(self, edge: tuple, circuit: QuantumCircuit) -> list:
 
-        """check if cnot is in allowed direction and add Hadamart gates if necessary
+        """check if cnot is in allowed direction and add Hadamard gates if necessary
 
         Args:
             edge (tuple): tuple representing qubits between cnot.
@@ -259,17 +257,18 @@ class PermRowCol:
         Returns:
 
         """
-        if edge not in self._coupling_map.get_edges() and (edge[1],edge[0]) in self._coupling_map.get_edges():
+        edges = self._coupling_map.get_edges()
+        print("edges:", edges)
+        if (
+            edge not in edges
+        ):  # and (edge[1],edge[0]) in self._coupling_map.get_edges():
+            print("add hadamard", edge)
             circuit.h(edge[0])
             circuit.h(edge[1])
-            circuit.cx(edge[0],edge[1])
+            circuit.cx(edge[0], edge[1])
             circuit.h(edge[0])
             circuit.h(edge[1])
 
-        # if edge not in self._coupling_map.get_edges() and (edge[1],edge[0]) in self._coupling_map.get_edges():
-        #     circuit.cx(edge[0],edge[1])
-
-        else:
-            circuit.cx(edge[0],edge[1])
-
-
+        elif edge in edges:
+            print("allowed:", edge)
+            circuit.cx(edge[0], edge[1])

--- a/qiskit/transpiler/synthesis/permrowcol.py
+++ b/qiskit/transpiler/synthesis/permrowcol.py
@@ -260,6 +260,7 @@ class PermRowCol:
             circuit.cx(edge[1], edge[0])
             circuit.h(edge[0])
             circuit.h(edge[1])
+            pass
 
-        elif edge in edges:
+        else:
             circuit.cx(edge[0], edge[1])

--- a/qiskit/transpiler/synthesis/permrowcol.py
+++ b/qiskit/transpiler/synthesis/permrowcol.py
@@ -243,16 +243,13 @@ class PermRowCol:
 
         return nodes
 
-    def _add_cnot(self, edge: tuple, circuit: QuantumCircuit) -> list:
+    def _add_cnot(self, edge: tuple, circuit: QuantumCircuit):
 
         """check if cnot is in allowed direction and add Hadamard gates if necessary
 
         Args:
             edge (tuple): tuple representing qubits between cnot.
             circuit (QuantumCircuit): QuantumCircuit for adding cnots
-
-
-        Returns:
 
         """
         edges = self._coupling_map.get_edges()

--- a/qiskit/transpiler/synthesis/permrowcol.py
+++ b/qiskit/transpiler/synthesis/permrowcol.py
@@ -258,11 +258,9 @@ class PermRowCol:
 
         """
         edges = self._coupling_map.get_edges()
-        print("edges:", edges)
-        if (
-            edge not in edges
-        ):  # and (edge[1],edge[0]) in self._coupling_map.get_edges():
-            print("add hadamard", edge)
+
+        if edge not in edges:  # and (edge[1],edge[0]) in self._coupling_map.get_edges():
+            # print("add hadamard", edge)
             circuit.h(edge[0])
             circuit.h(edge[1])
             circuit.cx(edge[0], edge[1])
@@ -270,5 +268,5 @@ class PermRowCol:
             circuit.h(edge[1])
 
         elif edge in edges:
-            print("allowed:", edge)
+            # print("allowed:", edge)
             circuit.cx(edge[0], edge[1])

--- a/qiskit/transpiler/synthesis/permrowcol.py
+++ b/qiskit/transpiler/synthesis/permrowcol.py
@@ -57,14 +57,12 @@ class PermRowCol:
             column = self.choose_column(parity_mat, cols, row)
             nodes = self._get_nodes(parity_mat, column)
             for edge in self._eliminate_column(parity_mat, row, column, nodes):
-                # circuit.cx(edge[0], edge[1])
                 self._add_cnot(edge, circuit)
 
             if sum(parity_mat[row]) > 1:
                 nodes = self._get_nodes_for_eliminate_row(parity_mat, column, row)
 
                 for edge in self._eliminate_row(parity_mat, row, nodes):
-                    # circuit.cx(edge[0], edge[1])  # Adds a CNOT to the circuit
                     self._add_cnot(edge, circuit)
 
             qubit_alloc[column] = row
@@ -259,8 +257,7 @@ class PermRowCol:
         """
         edges = self._coupling_map.get_edges()
 
-        if edge not in edges:  # and (edge[1],edge[0]) in self._coupling_map.get_edges():
-            # print("add hadamard", edge)
+        if edge not in edges:
             circuit.h(edge[0])
             circuit.h(edge[1])
             circuit.cx(edge[0], edge[1])
@@ -268,5 +265,4 @@ class PermRowCol:
             circuit.h(edge[1])
 
         elif edge in edges:
-            # print("allowed:", edge)
             circuit.cx(edge[0], edge[1])

--- a/qiskit/transpiler/synthesis/permrowcol.py
+++ b/qiskit/transpiler/synthesis/permrowcol.py
@@ -57,13 +57,15 @@ class PermRowCol:
             column = self.choose_column(parity_mat, cols, row)
             nodes = self._get_nodes(parity_mat, column)
             for edge in self._eliminate_column(parity_mat, row, column, nodes):
-                circuit.cx(edge[0], edge[1])
+                #circuit.cx(edge[0], edge[1])
+                self._add_cnot(edge,circuit)
 
             if sum(parity_mat[row]) > 1:
                 nodes = self._get_nodes_for_eliminate_row(parity_mat, column, row)
 
                 for edge in self._eliminate_row(parity_mat, row, nodes):
-                    circuit.cx(edge[0], edge[1])  # Adds a CNOT to the circuit
+                    #circuit.cx(edge[0], edge[1])  # Adds a CNOT to the circuit
+                    self._add_cnot(edge,circuit)
 
             qubit_alloc[column] = row
 
@@ -242,3 +244,32 @@ class PermRowCol:
         ]  # Finds indexes of rows that are added to chosen_row
 
         return nodes
+
+    def _add_cnot(
+        self, edge: tuple, circuit: QuantumCircuit
+    ) -> list:
+
+        """check if cnot is in allowed direction and add Hadamart gates if necessary
+
+        Args:
+            edge (tuple): tuple representing qubits between cnot.
+            circuit (QuantumCircuit): QuantumCircuit for adding cnots
+
+
+        Returns:
+
+        """
+        if edge not in self._coupling_map.get_edges() and (edge[1],edge[0]) in self._coupling_map.get_edges():
+            circuit.h(edge[0])
+            circuit.h(edge[1])
+            circuit.cx(edge[0],edge[1])
+            circuit.h(edge[0])
+            circuit.h(edge[1])
+
+        # if edge not in self._coupling_map.get_edges() and (edge[1],edge[0]) in self._coupling_map.get_edges():
+        #     circuit.cx(edge[0],edge[1])
+
+        else:
+            circuit.cx(edge[0],edge[1])
+
+

--- a/test/python/transpiler/test_permrowcol.py
+++ b/test/python/transpiler/test_permrowcol.py
@@ -10,7 +10,7 @@ from qiskit import QuantumCircuit
 from qiskit.transpiler import CouplingMap
 from qiskit.circuit.library.generalized_gates.permutation import Permutation
 from qiskit.transpiler.synthesis.matrix_utils import build_random_parity_matrix
-from qiskit.providers.fake_provider import FakeTenerife
+from qiskit.providers.fake_provider import FakeTenerife, FakeManilaV2
 
 
 class TestPermRowCol(QiskitTestCase):
@@ -502,14 +502,34 @@ class TestPermRowCol(QiskitTestCase):
         coupling = CouplingMap(coupling_list)
         permrowcol = PermRowCol(coupling)
         circuit, perm = permrowcol.perm_row_col(parity_mat)
-        h_gates = []
+        h_gates = 0
         for i in circuit:
             if i[0].name == "h":
-                h_gates.append(i)
-        self.assertEqual(len(h_gates), 0)
+                h_gates += 1
+        self.assertEqual(h_gates, 0)
 
-    def test_add_cnot_adds_four_hadamard_gates_if_cnot_is_in_wrong_direction(self):
+    def test_add_cnot_adds_exactly_four_hadamards_around_a_cnot_when_needed(self):
         """Test add one cnot to wrong direction adds four hadamard gates"""
+        backend = FakeTenerife()
+        data = backend.properties().to_dict()["gates"]
+        coupling_list = [tuple(item["qubits"]) for item in data if item["gate"] == "cx"]
+        coupling = CouplingMap(coupling_list)
+        n = 5
+        parity_mat = build_random_parity_matrix(42, n, 60)
+
+        circuit = QuantumCircuit(n)
+        permrowcol = PermRowCol(coupling)
+        circuit, perm = permrowcol.perm_row_col(parity_mat)
+
+        h_gates = 0
+        for i in circuit:
+            if i[0].name == "h":
+                h_gates += 1
+
+        self.assertEqual(h_gates % 4, 0)
+
+    def test_add_cnot_never_adds_hadamard_gates_if_opposite_cnot_is_allowed(self):
+        """Test add cnots does not add hadamards if the opposite edge is allowed, and so the existing hadamards are not unnecessary"""
         backend = FakeTenerife()
         data = backend.properties().to_dict()["gates"]
         coupling_list = [tuple(item["qubits"]) for item in data if item["gate"] == "cx"]
@@ -525,15 +545,53 @@ class TestPermRowCol(QiskitTestCase):
             if instruction[0].name == "cx":
                 qubit_0 = instruction[1][0]
                 qubit_1 = instruction[1][1]
-                if (qubit_0.index, qubit_1.index) not in coupling_list:
-                    self.assertEqual(circuit[index - 2][0].name, "h")
-                    self.assertEqual(circuit[index - 2][1][0], qubit_0)
-                    self.assertEqual(circuit[index - 1][0].name, "h")
-                    self.assertEqual(circuit[index - 1][1][0], qubit_1)
-                    self.assertEqual(circuit[index + 1][0].name, "h")
-                    self.assertEqual(circuit[index + 1][1][0], qubit_0)
-                    self.assertEqual(circuit[index + 2][0].name, "h")
-                    self.assertEqual(circuit[index + 2][1][0], qubit_1)
+                if circuit[index - 2][0].name == "h":
+                    opposite_edge = (qubit_1.index, qubit_0.index)
+                    self.assertEqual((opposite_edge in coupling_list), False)
+
+    def test_add_cnot_never_adds_cnots_that_are_not_allowed(self):
+        """Test circuit never contains any cnots in the wrong direction"""
+
+        backend = FakeTenerife()
+        data = backend.properties().to_dict()["gates"]
+        coupling_list = [tuple(item["qubits"]) for item in data if item["gate"] == "cx"]
+        coupling = CouplingMap(coupling_list)
+        n = 5
+        parity_mat = build_random_parity_matrix(42, n, 60)
+
+        circuit = QuantumCircuit(n)
+        permrowcol = PermRowCol(coupling)
+        circuit, perm = permrowcol.perm_row_col(parity_mat)
+
+        for index, instruction in enumerate(circuit):
+            if instruction[0].name == "cx":
+                qubit_0 = instruction[1][0]
+                qubit_1 = instruction[1][1]
+                edge = (qubit_0.index, qubit_1.index)
+                self.assertEqual((edge in coupling_list), True)
+
+    def test_add_cnot_never_adds_hadamard_gates_to_a_bidirectional_circuit(self):
+        """A bidirectional circuit will never have Hadamard gates added to it"""
+        # Change slightly later when `directed: bool` argument to perm_row_col() is added
+        backend = FakeManilaV2()
+        coupling_map = backend.coupling_map
+        coupling = CouplingMap(coupling_map)
+        permrowcol = PermRowCol(coupling)
+        n = 5
+        parity_mat = build_random_parity_matrix(42, n, 60)
+
+        circuit = QuantumCircuit(n)
+        permrowcol = PermRowCol(coupling)
+        circuit, perm = permrowcol.perm_row_col(parity_mat)
+        h_gates = 0
+
+        h_gates = 0
+
+        for i in circuit:
+            if i[0].name == "h":
+                h_gates += 1
+
+        self.assertEqual(h_gates, 0)
 
 
 if __name__ == "__main__":

--- a/test/python/transpiler/test_permrowcol.py
+++ b/test/python/transpiler/test_permrowcol.py
@@ -14,7 +14,6 @@ from qiskit.transpiler.synthesis.matrix_utils import build_random_parity_matrix
 from qiskit.providers.fake_provider import FakeTenerife
 
 
-
 class TestPermRowCol(QiskitTestCase):
     """Test PermRowCol"""
 
@@ -514,6 +513,8 @@ class TestPermRowCol(QiskitTestCase):
 
     def test_add_cnot_adds_four_hadamard_gates_if_cnot_is_in_wrong_direction(self):
         """Test add one cnot to wrong direction ads four cnots"""
+
+        print("Start test_add_cnot_adds_four_hadamard_gates_if_cnot_is_in_wrong_direction")
         coupling_list = [(0, 1), (0, 3), (1, 2), (1, 4), (2, 5), (3, 4), (4, 5)]
         coupling = CouplingMap(coupling_list)
         n = 6
@@ -522,30 +523,33 @@ class TestPermRowCol(QiskitTestCase):
         circuit = QuantumCircuit(n)
         permrowcol = PermRowCol(coupling)
         circuit, perm = permrowcol.perm_row_col(parity_mat)
-        #permrowcol._add_cnot((1, 0), circuit)
-       # print(circuit)
+        # permrowcol._add_cnot((1, 0), circuit)
+        # print(circuit)
 
         for index, instruction in enumerate(circuit):
 
-        #   self.assertEqual(instruction, circuit[index])
-            if instruction[0].name == 'cx':
+            #   self.assertEqual(instruction, circuit[index])
+            if instruction[0].name == "cx":
                 qubit_0 = instruction[1][0]
                 qubit_1 = instruction[1][1]
-        #        if (qubit_0, qubit_1) not in coupling_list:
-        #            self.assertEqual(circuit[index-2][0].name, 'h')
-        #            self.assertEqual(circuit[index-2][1][0], qubit_0)
-        #            self.assertEqual(circuit[index-1][0].name, 'h')
-        #            self.assertEqual(circuit[index-1][1][0], qubit_1)
-        #            self.assertEqual(circuit[index+1][0].name, 'h')
-        #            self.assertEqual(circuit[index+1][1][0], qubit_0)
-        #            self.assertEqual(circuit[index+2][0].name, 'h')
-        #            self.assertEqual(circuit[index+2][1][0], qubit_1)
+                # print(qubit_0.index)
+                # print(qubit_1.index)
+                if (qubit_0.index, qubit_1.index) not in coupling_list:
+                    # print(qubit_0.index)
+                    # print(qubit_1.index)
+                    self.assertEqual(circuit[index - 2][0].name, "h")
+                    self.assertEqual(circuit[index - 2][1][0], qubit_0)
+                    self.assertEqual(circuit[index - 1][0].name, "h")
+                    self.assertEqual(circuit[index - 1][1][0], qubit_1)
+                    self.assertEqual(circuit[index + 1][0].name, "h")
+                    self.assertEqual(circuit[index + 1][1][0], qubit_0)
+                    self.assertEqual(circuit[index + 2][0].name, "h")
+                    self.assertEqual(circuit[index + 2][1][0], qubit_1)
 
-
-            # if instruction[0].name == 'cx' and instruction[1].
-            #    circuit[index-2][0].name == 'h'
-        #print(gates)
-        #self.assertEqual(gates, correct)
+        # if instruction[0].name == 'cx' and instruction[1].
+        #    circuit[index-2][0].name == 'h'
+        # print(gates)
+        # self.assertEqual(gates, correct)
         # self.assertEqual(np.array_equal(instance, original_parity_map), True)
 
         # parity mat =random parity pat

--- a/test/python/transpiler/test_permrowcol.py
+++ b/test/python/transpiler/test_permrowcol.py
@@ -583,7 +583,6 @@ class TestPermRowCol(QiskitTestCase):
         circuit = QuantumCircuit(n)
         permrowcol = PermRowCol(coupling)
         circuit, perm = permrowcol.perm_row_col(parity_mat)
-        h_gates = 0
 
         h_gates = 0
 

--- a/test/python/transpiler/test_permrowcol.py
+++ b/test/python/transpiler/test_permrowcol.py
@@ -6,12 +6,10 @@ import retworkx as rx
 
 from qiskit.test import QiskitTestCase
 from qiskit.transpiler.synthesis.permrowcol import PermRowCol
-from qiskit.circuit.library import LinearFunction
-from qiskit import QuantumCircuit, QuantumRegister
+from qiskit import QuantumCircuit
 from qiskit.transpiler import CouplingMap
 from qiskit.circuit.library.generalized_gates.permutation import Permutation
 from qiskit.transpiler.synthesis.matrix_utils import build_random_parity_matrix
-from qiskit.providers.fake_provider import FakeTenerife
 
 
 class TestPermRowCol(QiskitTestCase):
@@ -509,12 +507,9 @@ class TestPermRowCol(QiskitTestCase):
                 h_gates.append(i)
         self.assertEqual(len(h_gates), 0)
 
-    # tox -epy38 -- -n test.python.transpiler.TestPermRowCol.test_add_cnot_adds_four_hadamard_gates_if_cnot_is_in_wrong_direction
-
     def test_add_cnot_adds_four_hadamard_gates_if_cnot_is_in_wrong_direction(self):
-        """Test add one cnot to wrong direction ads four cnots"""
+        """Test add one cnot to wrong direction adds four cnots"""
 
-        print("Start test_add_cnot_adds_four_hadamard_gates_if_cnot_is_in_wrong_direction")
         coupling_list = [(0, 1), (0, 3), (1, 2), (1, 4), (2, 5), (3, 4), (4, 5)]
         coupling = CouplingMap(coupling_list)
         n = 6
@@ -523,20 +518,12 @@ class TestPermRowCol(QiskitTestCase):
         circuit = QuantumCircuit(n)
         permrowcol = PermRowCol(coupling)
         circuit, perm = permrowcol.perm_row_col(parity_mat)
-        # permrowcol._add_cnot((1, 0), circuit)
-        # print(circuit)
 
         for index, instruction in enumerate(circuit):
-
-            #   self.assertEqual(instruction, circuit[index])
             if instruction[0].name == "cx":
                 qubit_0 = instruction[1][0]
                 qubit_1 = instruction[1][1]
-                # print(qubit_0.index)
-                # print(qubit_1.index)
                 if (qubit_0.index, qubit_1.index) not in coupling_list:
-                    # print(qubit_0.index)
-                    # print(qubit_1.index)
                     self.assertEqual(circuit[index - 2][0].name, "h")
                     self.assertEqual(circuit[index - 2][1][0], qubit_0)
                     self.assertEqual(circuit[index - 1][0].name, "h")
@@ -546,25 +533,6 @@ class TestPermRowCol(QiskitTestCase):
                     self.assertEqual(circuit[index + 2][0].name, "h")
                     self.assertEqual(circuit[index + 2][1][0], qubit_1)
 
-        # if instruction[0].name == 'cx' and instruction[1].
-        #    circuit[index-2][0].name == 'h'
-        # print(gates)
-        # self.assertEqual(gates, correct)
-        # self.assertEqual(np.array_equal(instance, original_parity_map), True)
-
-        # parity mat =random parity pat
-        # coupling = fakebackend coupling map
-        # circuit, perm = permrowcol.perm_row col()
-        # circuit_data = circuit.data
-        # in a loop:
-        # if circuit_data(i) = cx and not in coupling map
-        # selfassertequal(circuit_data(i-2)) = h and qubit = toinen coupling mapin nodeista
-        # selfassertequal(circuit_data(i-1)) = h -''-
-        # selfassertequal(circuit_data(i+1)) = h -''-
-        # selfassertequal(circuit_data(i+2)) = h -''-
-
-
-# QuantumCircuit.swap(qubit1, qubit2)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/transpiler/test_permrowcol.py
+++ b/test/python/transpiler/test_permrowcol.py
@@ -511,8 +511,8 @@ class TestPermRowCol(QiskitTestCase):
     def test_add_cnot_adds_four_hadamard_gates_if_cnot_is_in_wrong_direction(self):
         """Test add one cnot to wrong direction adds four hadamard gates"""
         backend = FakeTenerife()
-        data = backend.properties().to_dict()['gates']
-        coupling_list = [tuple(item['qubits']) for item in data if item['gate'] == 'cx']
+        data = backend.properties().to_dict()["gates"]
+        coupling_list = [tuple(item["qubits"]) for item in data if item["gate"] == "cx"]
         coupling = CouplingMap(coupling_list)
         n = 5
         parity_mat = build_random_parity_matrix(42, n, 60)

--- a/test/python/transpiler/test_permrowcol.py
+++ b/test/python/transpiler/test_permrowcol.py
@@ -10,6 +10,7 @@ from qiskit import QuantumCircuit
 from qiskit.transpiler import CouplingMap
 from qiskit.circuit.library.generalized_gates.permutation import Permutation
 from qiskit.transpiler.synthesis.matrix_utils import build_random_parity_matrix
+from qiskit.providers.fake_provider import FakeTenerife
 
 
 class TestPermRowCol(QiskitTestCase):
@@ -509,11 +510,12 @@ class TestPermRowCol(QiskitTestCase):
 
     def test_add_cnot_adds_four_hadamard_gates_if_cnot_is_in_wrong_direction(self):
         """Test add one cnot to wrong direction adds four hadamard gates"""
-
-        coupling_list = [(0, 1), (0, 3), (1, 2), (1, 4), (2, 5), (3, 4), (4, 5)]
+        backend = FakeTenerife()
+        data = backend.properties().to_dict()['gates']
+        coupling_list = [tuple(item['qubits']) for item in data if item['gate'] == 'cx']
         coupling = CouplingMap(coupling_list)
-        n = 6
-        parity_mat = build_random_parity_matrix(42, 6, 60)
+        n = 5
+        parity_mat = build_random_parity_matrix(42, n, 60)
 
         circuit = QuantumCircuit(n)
         permrowcol = PermRowCol(coupling)

--- a/test/python/transpiler/test_permrowcol.py
+++ b/test/python/transpiler/test_permrowcol.py
@@ -11,7 +11,8 @@ from qiskit import QuantumCircuit, QuantumRegister
 from qiskit.transpiler import CouplingMap
 from qiskit.circuit.library.generalized_gates.permutation import Permutation
 from qiskit.transpiler.synthesis.matrix_utils import build_random_parity_matrix
-from qiskit.providers.fake_provider import FakeManilaV2
+from qiskit.providers.fake_provider import FakeTenerife
+
 
 
 class TestPermRowCol(QiskitTestCase):
@@ -495,39 +496,8 @@ class TestPermRowCol(QiskitTestCase):
         permrowcol._reduce_graph(2)
         self.assertCountEqual(permrowcol._graph.edge_list(), [])
 
-    def test_perm_row_col_does_correct_permutation_matrix(self):
-        """Test Not to be included to the final commit"""
-        coupling_list = [(0, 1), (0, 3), (1, 2), (1, 4), (2, 5), (3, 4), (4, 5)]
-        coupling = CouplingMap(coupling_list)
-        permrowcol = PermRowCol(coupling)
-        parity_mat = np.array(
-            [
-                [0, 1, 0, 1, 1, 0],
-                [1, 1, 1, 1, 1, 0],
-                [1, 0, 0, 0, 1, 1],
-                [1, 1, 1, 0, 1, 0],
-                [1, 0, 1, 0, 1, 0],
-                [1, 0, 1, 0, 1, 1],
-            ]
-        )
-
-        correct_permutation_matrix = np.array(
-            [
-                [0, 0, 0, 1, 0, 0],
-                [0, 0, 1, 0, 0, 0],
-                [0, 0, 0, 0, 0, 1],
-                [0, 1, 0, 0, 0, 0],
-                [0, 0, 0, 0, 1, 0],
-                [1, 0, 0, 0, 0, 0],
-            ]
-        )
-
-        circuit, perm = permrowcol.perm_row_col(parity_mat)
-
-        self.assertEqual(np.array_equal(parity_mat, correct_permutation_matrix), True)
-
-    def test_no_hadamart_gates_added_with_complete_graph(self):
-        """Test that no hadamart gates are added if graph has bidirectional edges"""
+    def test_no_hadamard_gates_added_with_complete_graph(self):
+        """Test that no hadamard gates are added if graph has bidirectional edges"""
         n = 6
         parity_mat = build_random_parity_matrix(42, n, 60)
         coupling_list = [(i, j) for i in range(n) for j in range(n) if i != j]
@@ -536,26 +506,61 @@ class TestPermRowCol(QiskitTestCase):
         circuit, perm = permrowcol.perm_row_col(parity_mat)
         h_gates = []
         for i in circuit:
-            if i[0].name == 'h':
+            if i[0].name == "h":
                 h_gates.append(i)
-        self.assertEqual(len(h_gates),0)
+        self.assertEqual(len(h_gates), 0)
 
-    def test_add_cdot_ads_four_hadamart_gates_if_cnot_is_in_wrong_direction(self):
+    # tox -epy38 -- -n test.python.transpiler.TestPermRowCol.test_add_cnot_adds_four_hadamard_gates_if_cnot_is_in_wrong_direction
+
+    def test_add_cnot_adds_four_hadamard_gates_if_cnot_is_in_wrong_direction(self):
         """Test add one cnot to wrong direction ads four cnots"""
-        n = 6
-        parity_mat = build_random_parity_matrix(42, n, 60)
-        coupling_list = coupling_list = [(0, 1), (0, 3), (1, 2), (1, 4), (2, 5), (3, 4), (4, 5)]
+        coupling_list = [(0, 1), (0, 3), (1, 2), (1, 4), (2, 5), (3, 4), (4, 5)]
         coupling = CouplingMap(coupling_list)
+        n = 6
+        parity_mat = build_random_parity_matrix(42, 6, 60)
+
         circuit = QuantumCircuit(n)
         permrowcol = PermRowCol(coupling)
-        permrowcol._add_cnot((1,0),circuit)
-        print(circuit)
-        gates = []
-        correct = ['h','h','cx','h','h']
-        for i in circuit:
-            gates.append(i[0].name)
-        self.assertEqual(len(gates),len(correct))
+        circuit, perm = permrowcol.perm_row_col(parity_mat)
+        #permrowcol._add_cnot((1, 0), circuit)
+       # print(circuit)
 
+        for index, instruction in enumerate(circuit):
+
+        #   self.assertEqual(instruction, circuit[index])
+            if instruction[0].name == 'cx':
+                qubit_0 = instruction[1][0]
+                qubit_1 = instruction[1][1]
+        #        if (qubit_0, qubit_1) not in coupling_list:
+        #            self.assertEqual(circuit[index-2][0].name, 'h')
+        #            self.assertEqual(circuit[index-2][1][0], qubit_0)
+        #            self.assertEqual(circuit[index-1][0].name, 'h')
+        #            self.assertEqual(circuit[index-1][1][0], qubit_1)
+        #            self.assertEqual(circuit[index+1][0].name, 'h')
+        #            self.assertEqual(circuit[index+1][1][0], qubit_0)
+        #            self.assertEqual(circuit[index+2][0].name, 'h')
+        #            self.assertEqual(circuit[index+2][1][0], qubit_1)
+
+
+            # if instruction[0].name == 'cx' and instruction[1].
+            #    circuit[index-2][0].name == 'h'
+        #print(gates)
+        #self.assertEqual(gates, correct)
+        # self.assertEqual(np.array_equal(instance, original_parity_map), True)
+
+        # parity mat =random parity pat
+        # coupling = fakebackend coupling map
+        # circuit, perm = permrowcol.perm_row col()
+        # circuit_data = circuit.data
+        # in a loop:
+        # if circuit_data(i) = cx and not in coupling map
+        # selfassertequal(circuit_data(i-2)) = h and qubit = toinen coupling mapin nodeista
+        # selfassertequal(circuit_data(i-1)) = h -''-
+        # selfassertequal(circuit_data(i+1)) = h -''-
+        # selfassertequal(circuit_data(i+2)) = h -''-
+
+
+# QuantumCircuit.swap(qubit1, qubit2)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/transpiler/test_permrowcol.py
+++ b/test/python/transpiler/test_permrowcol.py
@@ -508,7 +508,7 @@ class TestPermRowCol(QiskitTestCase):
         self.assertEqual(len(h_gates), 0)
 
     def test_add_cnot_adds_four_hadamard_gates_if_cnot_is_in_wrong_direction(self):
-        """Test add one cnot to wrong direction adds four cnots"""
+        """Test add one cnot to wrong direction adds four hadamard gates"""
 
         coupling_list = [(0, 1), (0, 3), (1, 2), (1, 4), (2, 5), (3, 4), (4, 5)]
         coupling = CouplingMap(coupling_list)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Add functionality  to `PermRowCol` that adds Hadamard gates to the circuit.


### Details and comments
Add a function `_add_cnot()` to the class `PermRowCol`. The function is run whenever a cnot is added to a circuit, and it checks if the direction of the cnot is correct, and if not, four Hadamard gates are added to correct the direction. In addition, two tests are added: one to test that no  Hadamard gates are added to a complete graph, and one to check that if a cnot is in the wrong direction, it has Hadamard gates around it.

